### PR TITLE
Pin luci-theme-argon to tag 2.3.2 by cloning then checking out tag

### DIFF
--- a/diy-part2-21.02-optimized.sh
+++ b/diy-part2-21.02-optimized.sh
@@ -446,6 +446,14 @@ function setup_third_party_packages() {
         echo "🌐 Cloning third-party packages..."
         git clone --depth 1 https://github.com/217heidai/OpenWrt-Packages.git package/custom/OpenWrt-Packages
     fi
+
+    # Pin luci-theme-argon to tag 2.3.2
+    drop_package "luci-theme-argon"
+    if [ ! -d "package/custom/luci-theme-argon" ]; then
+        echo "🎨 Cloning luci-theme-argon (tag 2.3.2)..."
+        git clone https://github.com/jerrykuku/luci-theme-argon package/custom/luci-theme-argon
+        git -C package/custom/luci-theme-argon checkout tags/2.3.2
+    fi
     
     # Clean conflicting packages
     # clean_packages package/custom/OpenWrt-Packages


### PR DESCRIPTION
### Motivation
- Ensure the script pins `luci-theme-argon` to the `2.3.2` tag even when no branch named `2.3.2` exists, avoiding a failed `--branch` clone.

### Description
- Add `drop_package "luci-theme-argon"` and update `diy-part2-21.02-optimized.sh` to `git clone` the repository and then run `git -C package/custom/luci-theme-argon checkout tags/2.3.2` when `package/custom/luci-theme-argon` is absent.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710018763c8331b730258b6446b56c)