### PR TITLE
Handle v2.3.2 luci-theme-argon tag naming

### DIFF
--- a/diy-part2-21.02-optimized.sh
+++ b/diy-part2-21.02-optimized.sh
@@ -446,6 +446,20 @@ function setup_third_party_packages() {
         echo "🌐 Cloning third-party packages..."
         git clone --depth 1 https://github.com/217heidai/OpenWrt-Packages.git package/custom/OpenWrt-Packages
     fi
+
+    # Pin luci-theme-argon to tag 2.3.2
+    drop_package "luci-theme-argon"
+    if [ ! -d "package/custom/luci-theme-argon" ]; then
+        echo "🎨 Cloning luci-theme-argon (tag 2.3.2)..."
+        git clone https://github.com/jerrykuku/luci-theme-argon package/custom/luci-theme-argon
+    fi
+    git -C package/custom/luci-theme-argon fetch --tags --force
+    if ! git -C package/custom/luci-theme-argon checkout -q tags/v2.3.2; then
+        git -C package/custom/luci-theme-argon checkout -q tags/2.3.2 || {
+            echo "❌ Failed to checkout luci-theme-argon tag v2.3.2"
+            exit 1
+        }
+    fi
     
     # Clean conflicting packages
     # clean_packages package/custom/OpenWrt-Packages


### PR DESCRIPTION
### Motivation
- The script previously attempted to pin `luci-theme-argon` to tag `2.3.2` but failed to account for tags prefixed with `v` (e.g. `v2.4.3`), which can leave the package at an unintended newer version.
- A local inspection showed `git describe --tags --abbrev=0` returning `v2.4.3`, motivating a more robust checkout that handles both naming conventions.

### Description
- Ensure the repo under `package/custom/luci-theme-argon` is present and run `git -C package/custom/luci-theme-argon fetch --tags --force` to retrieve tags.
- Attempt to `checkout -q tags/v2.3.2` first and fall back to `checkout -q tags/2.3.2` if the `v`-prefixed tag is not present.
- On failure to find either tag the script prints an error and exits non-zero, and the function still calls `drop_package "luci-theme-argon"` and clones when missing.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710018763c8331b730258b6446b56c)